### PR TITLE
Configure auth and config services

### DIFF
--- a/auth-service/src/main/resources/application.properties
+++ b/auth-service/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=auth-service

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: auth-service
+  config:
+    import: "optional:configserver:http://localhost:8888"
+server:
+  port: 8081
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka
+    register-with-eureka: false
+    fetch-registry: false

--- a/config-service/src/main/resources/application.properties
+++ b/config-service/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=config-service

--- a/config-service/src/main/resources/application.yml
+++ b/config-service/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: config-service
+  profiles:
+    active: native
+  cloud:
+    config:
+      server:
+        native:
+          search-locations: classpath:/config
+server:
+  port: 8888
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka
+    register-with-eureka: false
+    fetch-registry: false

--- a/config-service/src/main/resources/config/auth-service.yml
+++ b/config-service/src/main/resources/config/auth-service.yml
@@ -1,0 +1,6 @@
+server:
+  port: 8081
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka


### PR DESCRIPTION
## Summary
- use YAML configuration for authentication service with config server and eureka references
- use YAML for config service's native filesystem backend and eureka client settings
- provide YAML sample auth-service settings served by config service

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_688df49636b4832db08581b871ec098d